### PR TITLE
docs: install with --locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ English | [中文](README_zh.md)
 The package is published to crates.io and can be installed directly using:
 
 ```bash
-cargo install excel-cli
+cargo install excel-cli --locked
 ```
 
 #### Option 2: Download from GitHub Release
@@ -45,7 +45,7 @@ cd excel-cli
 cargo build --release
 
 # Install to system
-cargo install --path .
+cargo install --path . --locked
 ```
 
 ### Uninstallation


### PR DESCRIPTION
Hi! Thanks for creating and sharing this wonderful cli app. I was looking for a lightweight tool to read spreadsheets (LibreOffice is massive and overkill for my use-case), and this is perfect.

I don't know if this suggestion is correct, but, in my case, `cargo run` / `cargo build` runs fine, but `cargo install` breaks with ~10 errors. Apparently, it's because `cargo install` doesn't completely honor `Cargo.lock` unless `--locked` (or `--frozen`) is passed.

All the reported errors, when running without `--locked`, are related to `the trait bound impl ratatui::widgets::Widget + '_: Widget is not satisfied` and `mismatched types`.

It looks like it resolves two different versions of `ratatui`, `0.24` and `0.29`:

```
= note: `Style` and `ratatui::style::Style` have similar names, but are actually distinct types
note: `Style` is defined in crate `ratatui`
    --> /home/taro/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ratatui-0.24.0/src/style.rs:192:1
     |
192  | pub struct Style {
     | ^^^^^^^^^^^^^^^^
note: `ratatui::style::Style` is defined in crate `ratatui`
    --> /home/taro/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ratatui-0.29.0/src/style.rs:247:1
     |
247  | pub struct Style {
     | ^^^^^^^^^^^^^^^^
     = note: perhaps two different versions of crate `ratatui` are being used?
```

I think the "culprit" seems to be [tui-textarea](https://github.com/rhysd/tui-textarea/blob/501e2b543ddd065d877daedf578069528525872a/Cargo.toml#L45C1-L45C82):

```
ratatui = { version = ">=0.23.0, <1", default-features = false, optional = true }
```

This difference in default behavior between `run` and `install` [seems to be a thing](https://github.com/rust-lang/cargo/issues/7169), and it's definitely very counter-intuitive.

I can kinda reproduce it if I remove the `Cargo.lock`:

```
$ cargo tree | grep tui
├── ratatui v0.24.0
└── tui-textarea v0.4.0
    ├── ratatui v0.24.0 (*)

$ rm Cargo.lock

$ cargo clean

$ cargo tree | grep tui
├── ratatui v0.24.0
└── tui-textarea v0.4.0
    ├── ratatui v0.29.0
```

`rm`'ing `Cargo.lock` actually causes `cargo build` to fail.
 
Upgrading ratatui to "0.27.0" and tui-textarea to "0.5.0" "fixes" this issue. 

```
$ cargo tree | grep tui
├── ratatui v0.27.0
└── tui-textarea v0.5.3
    ├── ratatui v0.27.0 (*)
```

I opened https://github.com/fuhan666/excel-cli/pull/11 with that dependency upgrade.

Optional dependencies are always such a pain...